### PR TITLE
adding range supports

### DIFF
--- a/lua/jq/api.lua
+++ b/lua/jq/api.lua
@@ -361,4 +361,21 @@ function M.run(opts)
   renderer:render(body)
 end
 
+---@type fun(opts?: jq.RunOpts): nil
+function M.run_visual(opts)
+  local start_line = vim.fn.line("'<")
+  local end_line = vim.fn.line("'>")
+  local bufnr = vim.api.nvim_get_current_buf()
+
+  local lines = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false)
+
+  local filename = vim.api.nvim_buf_get_name(bufnr)
+  opts = opts or {}
+
+  M.run(vim.tbl_extend("force", {
+    filename = filename,
+    lines = lines
+  }, opts))
+end
+
 return M

--- a/lua/jq/init.lua
+++ b/lua/jq/init.lua
@@ -1,5 +1,6 @@
 local M = {
   run = require("jq.api").run,
+  run_visual = require("jq.api").run_visual,
 }
 
 ---@param config jq.Config


### PR DESCRIPTION
First of all, thank you for creating jq.nvim — it’s a very useful, I Really appreciate your work 

This PR adds range support, allowing jq to be executed only on a selected
visual or line range instead of always using the full buffer.

This helps when you are working with the rest.nvim, because you can inspect you response json directly without create new file for the response.